### PR TITLE
Локализация: выносим хардкод и дозаполняем de/it/ru

### DIFF
--- a/recepies/Resources/Localizable.xcstrings
+++ b/recepies/Resources/Localizable.xcstrings
@@ -1,20 +1,309 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "2" : {
-
+    "home.toolbar.title" : {
+      "comment" : "Placeholder user name shown in the Home screen toolbar.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maxim, Cibulsky"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maxim, Cibulsky"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maxim, Cibulsky"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максим, Цибульский"
+          }
+        }
+      },
+      "extractionState" : "manual"
     },
-    "3" : {
-
+    "home.welcome" : {
+      "comment" : "Greeting label shown on the Home screen.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Willkommen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welcome"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benvenuto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добро пожаловать"
+          }
+        }
+      },
+      "extractionState" : "manual"
     },
-    "Jose Phonie" : {
-
+    "language.en" : {
+      "comment" : "Language picker option - English.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Englisch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "English"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inglese"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Английский"
+          }
+        }
+      }
     },
-    "Maxim, Cibulsky" : {
-
+    "language.ru" : {
+      "comment" : "Language picker option - Russian.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Russisch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Russian"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Russo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Русский"
+          }
+        }
+      }
+    },
+    "language.system" : {
+      "comment" : "Language picker option that follows the system language.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системный"
+          }
+        }
+      }
+    },
+    "search.tooltip.swipe" : {
+      "comment" : "Tooltip shown above the search header hinting that user can swipe to switch search mode.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wischen, um nach Zutaten zu suchen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swipe to search by ingredients"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scorri per cercare per ingredienti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свайпните для поиска по ингредиентам"
+          }
+        }
+      },
+      "extractionState" : "manual"
+    },
+    "settings.menu.download" : {
+      "comment" : "Settings menu item - opens downloaded content.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloads"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузки"
+          }
+        }
+      }
+    },
+    "settings.menu.language" : {
+      "comment" : "Settings menu item - opens the language picker.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprache"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lingua"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Язык"
+          }
+        }
+      }
+    },
+    "settings.menu.logout" : {
+      "comment" : "Settings menu item - signs the user out of the account.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abmelden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log out"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esci"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выйти"
+          }
+        }
+      }
+    },
+    "settings.menu.privacy" : {
+      "comment" : "Settings menu item - opens the privacy policy.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datenschutz"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Конфиденциальность"
+          }
+        }
+      }
     },
     "settings.menu.theme" : {
-      "extractionState" : "stale",
+      "comment" : "Settings menu item - opens the theme picker.",
+      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -30,46 +319,437 @@
         },
         "it" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Tema"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Тема"
           }
         }
       }
     },
-    "Swipe to search by ingredients" : {
-
-    },
-    "Theme" : {
-      "extractionState" : "stale",
+    "settings.menu.version %@" : {
+      "comment" : "Settings menu row showing the app version. %@ is the version string like 1.0.0.",
+      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Theme"
+            "value" : "Version: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version: %@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tema"
+            "value" : "Versione: %@"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Тема"
+            "value" : "Версия: %@"
           }
         }
       }
     },
-    "Welcome" : {
-
+    "settings.menu.wishlist" : {
+      "comment" : "Settings menu item - opens the user's wishlist.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wunschliste"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wishlist"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista dei desideri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Избранное"
+          }
+        }
+      }
+    },
+    "settings.profile.name" : {
+      "comment" : "Placeholder profile name shown in the Settings header.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jose Phonie"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jose Phonie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jose Phonie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Хосе Фони"
+          }
+        }
+      },
+      "extractionState" : "manual"
+    },
+    "settings.section.account" : {
+      "comment" : "Settings section title grouping account-related menu items.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konto"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аккаунт"
+          }
+        }
+      }
+    },
+    "settings.section.media" : {
+      "comment" : "Settings section title grouping media-related menu items (wishlist, downloads).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medien"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Media"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Media"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Медиа"
+          }
+        }
+      }
+    },
+    "settings.section.preferences" : {
+      "comment" : "Settings section title grouping preference items (theme, language).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preferences"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preferenze"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки"
+          }
+        }
+      }
+    },
+    "tab.item.discover" : {
+      "comment" : "Tab bar label for the Discover tab.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entdecken"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Discover"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scopri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обзор"
+          }
+        }
+      }
+    },
+    "tab.item.favorites" : {
+      "comment" : "Tab bar label for the Favorites tab.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoriten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorites"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preferiti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Избранное"
+          }
+        }
+      }
+    },
+    "tab.item.home" : {
+      "comment" : "Tab bar label for the Home tab.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Главная"
+          }
+        }
+      }
+    },
+    "tab.item.settings" : {
+      "comment" : "Tab bar label for the Settings tab.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки"
+          }
+        }
+      }
+    },
+    "theme.dark" : {
+      "comment" : "Theme picker option - dark appearance.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dunkel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scuro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тёмная"
+          }
+        }
+      }
+    },
+    "theme.light" : {
+      "comment" : "Theme picker option - light appearance.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hell"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiaro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Светлая"
+          }
+        }
+      }
+    },
+    "theme.newYear" : {
+      "comment" : "Theme picker option - seasonal New Year theme.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neujahr"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Year"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capodanno"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Новогодняя"
+          }
+        }
+      }
+    },
+    "theme.unspecified" : {
+      "comment" : "Theme picker option that follows the system appearance setting.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системная"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/recepies/Sources/Home/HomeView.swift
+++ b/recepies/Sources/Home/HomeView.swift
@@ -7,7 +7,7 @@ struct HomeView: View {
             ZStack {
                 Color.green.opacity(0.2).ignoresSafeArea()
                 
-                Text("Welcome")
+                Text("home.welcome")
             }
             .toolbar {
                 ToolbarItem(placement: .principal) {
@@ -47,7 +47,7 @@ private extension HomeView {
 private extension HomeView {
     
     var toolbarTitle: some View {
-        Text("Maxim, Cibulsky")
+        Text("home.toolbar.title")
         .font(.caption)
         .foregroundStyle(.primary)
         .border(Color.blue)

--- a/recepies/Sources/Home/UIKit/Language/LanguageType.swift
+++ b/recepies/Sources/Home/UIKit/Language/LanguageType.swift
@@ -1,24 +1,24 @@
-import Foundation
+import SwiftUI
 
 enum LanguageType: String, CaseIterable, Identifiable {
     case system
     case ru
     case en
-    
+
     var id: String { rawValue }
-    
+
     var localeIdentifier: String? {
         self == .system ? nil : rawValue
     }
-    
-    var displayName: String {
+
+    var displayName: LocalizedStringKey {
         switch self {
         case .ru:
-            "Русский"
+            "language.ru"
         case .en:
-            "English"
-        default:
-            "Системная"
+            "language.en"
+        case .system:
+            "language.system"
         }
     }
 }

--- a/recepies/Sources/Home/UIKit/Theme/ThemeTypes.swift
+++ b/recepies/Sources/Home/UIKit/Theme/ThemeTypes.swift
@@ -1,13 +1,13 @@
-import Foundation
+import SwiftUI
 
 enum ThemeTypes: Int, Codable, CaseIterable, Identifiable {
     case unspecified
     case light
     case dark
     case newYear
-    
+
     var id: Int { rawValue }
-    
+
     init?(rawValue: Int) {
         switch rawValue {
         case 0: self = .unspecified
@@ -17,17 +17,17 @@ enum ThemeTypes: Int, Codable, CaseIterable, Identifiable {
         default: self = .unspecified
         }
     }
-    
-    var displayName: String {
+
+    var displayName: LocalizedStringKey {
         switch self {
         case .unspecified:
-            "Не выбранный"
+            "theme.unspecified"
         case .light:
-            "Светлая"
+            "theme.light"
         case .dark:
-            "Тёмная"
+            "theme.dark"
         case .newYear:
-            "Новогодняя"
+            "theme.newYear"
         }
     }
 }

--- a/recepies/Sources/RecepiesApp.swift
+++ b/recepies/Sources/RecepiesApp.swift
@@ -31,17 +31,17 @@ struct ContentApp: View {
             .badge(2)
             .tabItem { Label("tab.item.home", systemImage: "person.circle.fill") }
             
-            Text("2")
-            .tabItem { Label("Home", systemImage: "person.circle.fill") }
-            
-            Text("3")
+            Text(verbatim: "2")
+            .tabItem { Label("tab.item.discover", systemImage: "person.circle.fill") }
+
+            Text(verbatim: "3")
             .tabItem {
                 Label("tab.item.favorites", systemImage: "bookmark.fill")
             }
-            
+
             SettingsView(viewModel: settingsViewModel)
             .tabItem {
-                Label("Настройки", systemImage: "person.circle.fill")
+                Label("tab.item.settings", systemImage: "person.circle.fill")
             }
         }
         .accentColor(.label.secondary)

--- a/recepies/Sources/SearchResults/SearchResultsUi.swift
+++ b/recepies/Sources/SearchResults/SearchResultsUi.swift
@@ -133,7 +133,7 @@ private extension SearchResultsUi {
     }
     
     var helpTooltipTitle: some View {
-        Text("Swipe to search by ingredients")
+        Text("search.tooltip.swipe")
         .font(.callout)
         .foregroundColor(.label.primary)
         .fontWeight(.bold)

--- a/recepies/Sources/Settings/Data/MenuSectionType.swift
+++ b/recepies/Sources/Settings/Data/MenuSectionType.swift
@@ -1,15 +1,15 @@
-import Foundation
+import SwiftUI
 
 enum MenuSectionType {
     case media
     case preferences
     case account
-    
-    var title: String {
+
+    var title: LocalizedStringKey {
         switch self {
-        case .media: return "Media"
-        case .preferences: return "Preferences"
-        case .account: return "Account"
+        case .media: "settings.section.media"
+        case .preferences: "settings.section.preferences"
+        case .account: "settings.section.account"
         }
     }
 }

--- a/recepies/Sources/Settings/SettingsView.swift
+++ b/recepies/Sources/Settings/SettingsView.swift
@@ -47,7 +47,7 @@ private extension SettingsView {
             .shadow(radius: 8)
             .foregroundStyle(Color.label.secondary)
             
-            Text("Jose Phonie")
+            Text("settings.profile.name")
             .font(.title3)
             .fontWeight(.bold)
             .foregroundStyle(Color.element.primary)
@@ -76,7 +76,7 @@ private extension SettingsView {
         }
     }
     
-    func menuSection(title: String) -> some View {
+    func menuSection(title: LocalizedStringKey) -> some View {
         Text(title)
         .font(.title2)
         .fontWeight(.semibold)
@@ -128,7 +128,7 @@ private extension SettingsView {
                 VStack(spacing: showDivider ? 12 : 0) {
                     HStack {
                         setupCell(icon: "heart")
-                        setupCell(title: "Wishlist")
+                        setupCell(title: "settings.menu.wishlist")
                         
                         Spacer()
                         
@@ -154,7 +154,7 @@ private extension SettingsView {
                 VStack(spacing: showDivider ? 12 : 0) {
                     HStack {
                         setupCell(icon: "icloud.and.arrow.down")
-                        setupCell(title: "Download")
+                        setupCell(title: "settings.menu.download")
                         
                         Spacer()
                         
@@ -177,11 +177,11 @@ private extension SettingsView {
         VStack(spacing: showDivider ? 12 : 0) {
             HStack {
                 setupCell(icon: "moon")
-                setupCell(title: LocalizedStringKey("settings.menu.theme"))
-                
+                setupCell(title: "settings.menu.theme")
+
                 Spacer()
-                
-                Picker("Theme", selection: $themeManager.currentThemeType) {
+
+                Picker("settings.menu.theme", selection: $themeManager.currentThemeType) {
                     ForEach(ThemeTypes.allCases, id: \.id) { theme in
                         Text(theme.displayName).tag(theme)
                     }
@@ -207,11 +207,11 @@ private extension SettingsView {
                 VStack(spacing: showDivider ? 12 : 0) {
                     HStack {
                         setupCell(icon: "globe.badge.chevron.backward")
-                        setupCell(title: "Language")
-                        
+                        setupCell(title: "settings.menu.language")
+
                         Spacer()
-                        
-                        Picker("Language", selection: $languageManager.currentLanguage) {
+
+                        Picker("settings.menu.language", selection: $languageManager.currentLanguage) {
                             ForEach(LanguageType.allCases, id: \.id) { lang in
                                 Text(lang.displayName).tag(lang)
                             }
@@ -238,7 +238,7 @@ private extension SettingsView {
                 VStack(spacing: showDivider ? 12 : 0) {
                     HStack {
                         setupCell(icon: "rectangle.portrait.and.arrow.forward")
-                        setupCell(title: "Logout")
+                        setupCell(title: "settings.menu.logout")
                         
                         Spacer()
                         
@@ -264,7 +264,7 @@ private extension SettingsView {
                 VStack(spacing: showDivider ? 12 : 0) {
                     HStack {
                         setupCell(icon: "person.badge.shield.checkmark.fill")
-                        setupCell(title: "Privacy")
+                        setupCell(title: "settings.menu.privacy")
                         
                         Spacer()
                         
@@ -284,10 +284,11 @@ private extension SettingsView {
 private extension SettingsView {
     
     func getVersionCell(showDivider: Bool, version: String) -> some View {
-        VStack(spacing: showDivider ? 12 : 0) {
+        let title: LocalizedStringKey = "settings.menu.version \(version)"
+        return VStack(spacing: showDivider ? 12 : 0) {
             HStack {
                 setupCell(icon: "doc.append.fill.rtl")
-                setupCell(title: "Version: \(version)")
+                setupCell(title: title)
                 
                 Spacer()
                 


### PR DESCRIPTION
Почистил хардкод строк по экранам и довёл каталог локализации до рабочего состояния.

## Что поменялось

- Табы в `RecepiesApp` - вместо смеси `"Home"` / `"Настройки"` / `Text("2")` теперь ключи `tab.item.*`. Цифровые заглушки оставил как `Text(verbatim:)` чтобы Xcode не тащил их в экстракт.
- `SettingsView` - профильное имя, пункты меню (Wishlist, Download, Theme, Language, Log out, Privacy), заголовки секций, title пикеров и строка версии - всё через `LocalizedStringKey`. Строку версии сделал через интерполяцию `"settings.menu.version \(version)"`, чтобы Xcode сам сгенерил ключ с `%@`.
- `HomeView` - `Welcome` и плейсхолдерный ник в тулбаре переехали в ключи.
- `SearchResultsUi` - тултип про свайп по ингредиентам.
- `LanguageType.displayName`, `ThemeTypes.displayName`, `MenuSectionType.title` - вернули `LocalizedStringKey` вместо `String`. Пришлось заменить `import Foundation` на `import SwiftUI` в этих файлах.

## String Catalog

- Выкинул мусорные пустые ключи (`"2"`, `"3"`, `"Jose Phonie"`, `"Maxim, Cibulsky"`, `"Welcome"` и т.п.) и протухший `"Theme"`.
- 25 семантических ключей, по всем четырём языкам (en, de, it, ru) - немецкий был на 4%, теперь закрыт.
- К каждой записи добавил `comment` с контекстом, чтобы переводчику было понятно, где это висит в UI.
- Проставил `extractionState: "manual"` везде. Нужно из-за того, что ключи ходят через enum (`displayName`) и хелпер `setupCell(title:)` - экстрактор Xcode такое не распознаёт и иначе мигает `stale`.

## Что сознательно не трогал

- `Color.green` / `Color.white` в `HomeView` и `SearchResultsUi` - это про тему, отдельная задача.
- `HomeView` не подключён в `TabView`, там всё ещё заглушки `Text("2")`/`Text("3")` - отдельный тикет.
- Экшены в `SettingsView` (`print("Execution wishlist")` и т.п.) - тоже отдельно.
- Русские литералы в `#Preview` у `UIKitButton` - вне скоупа этого PR.

## Проверял

- `tuist build` - зелёный, `Localizable.strings` копируется для всех четырёх языков.
- В String Catalog все 4 языка на 100%, stale-варнингов нет.
- Прошёл грепом по `Text("[A-Z]...`, `Picker("...`, `Label("...` - пусто.