### PR TITLE
MVI для SearchResults - State, Intent, Reducer, SideEffect, тесты

### DIFF
--- a/recepies/Resources/Localizable.xcstrings
+++ b/recepies/Resources/Localizable.xcstrings
@@ -151,6 +151,66 @@
         }
       }
     },
+    "search.empty.subtitle" : {
+      "comment" : "Empty search results subtitle prompting user to retry.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versuche eine andere Anfrage"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try a different query"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prova una ricerca diversa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Попробуй другой запрос"
+          }
+        }
+      }
+    },
+    "search.empty.title" : {
+      "comment" : "Empty search results title.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nichts gefunden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing found"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun risultato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ничего не нашли"
+          }
+        }
+      }
+    },
     "search.tooltip.swipe" : {
       "comment" : "Tooltip shown above the search header hinting that user can swipe to switch search mode.",
       "localizations" : {

--- a/recepies/Sources/AppDelegate.swift
+++ b/recepies/Sources/AppDelegate.swift
@@ -1,9 +1,9 @@
 import UIKit
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     var window: UIWindow?
-
+    
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
@@ -18,5 +18,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         return true
     }
-
 }

--- a/recepies/Sources/Home/Services/Network/NetworkServiceImpl.swift
+++ b/recepies/Sources/Home/Services/Network/NetworkServiceImpl.swift
@@ -43,5 +43,4 @@ final class NetworkServiceImpl: NetworkService {
         
         return response.statusCode ~= 200
     }
-    
 }

--- a/recepies/Sources/SearchResults/SearchIntent.swift
+++ b/recepies/Sources/SearchResults/SearchIntent.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum SearchIntent: Equatable {
+    case submit(String)
+    case resultsLoaded([String])
+    case clear
+    case selectHistory(Int)
+}

--- a/recepies/Sources/SearchResults/SearchResultsUi.swift
+++ b/recepies/Sources/SearchResults/SearchResultsUi.swift
@@ -6,69 +6,140 @@ struct SearchResultsUi: View {
     
     @EnvironmentObject var themeManager: ThemeManager
     
-    private let historyData: [String] = [
-        "My search history",
-        "My favourite recipes",
-        "My favourite recipes",
-        "My favourite recipes",
-        "My favourite recipes",
-        "Easy Mexican Casserole",
-        "My favourite recipes",
-        "My favourite recipes",
-        "My favourite recipes",
-    ]
+    @State private var store = SearchStore()
+    @State private var queryInput: String = ""
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             header
-            search
+            sheet
         }
-        .background(Color.white)
+        .background(Color.background.primary)
     }
     
-    // MARK: - search
+    // MARK: - Sheet
     
-    var search: some View {
-        ScrollView(showsIndicators: false) {
-            VStack {
-                ForEach(historyData.indices, id: \.self) { index in
-                    cell(
-                        title: historyData[index],
-                        isDividerExist: historyData.count - 1 != index
-                    )
+    private var sheet: some View {
+        VStack(spacing: 0) {
+            searchField
+            content
+        }
+        .background(Color.background.primary)
+        .cornerRadius(24, corners: [.topLeft, .topRight])
+        .offset(y: -36)
+    }
+    
+    // MARK: - Search field
+    
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.label.secondary)
+            
+            TextField("search.tooltip.swipe", text: $queryInput)
+                .textFieldStyle(.plain)
+                .submitLabel(.search)
+                .onSubmit {
+                    store.send(.submit(queryInput))
+                }
+            
+            if queryInput.isEmpty == false {
+                Button {
+                    queryInput = ""
+                    store.send(.clear)
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.label.secondary)
                 }
             }
         }
-        .padding(.top, 6)
-        .background(Color.white)
-        .cornerRadius(24, corners: [.topLeft, .topRight])
-        .offset(x: 0, y: -36)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color.background.ghost, in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 24)
+        .padding(.top, 20)
+        .padding(.bottom, 12)
     }
     
-    func cell(
-        title: String,
-        isDividerExist: Bool
-    ) -> some View {
-        VStack {
-            HStack {
-                Text(title)
-                .font(.description.customWeight(.heavy))
-                
-                Spacer()
-                
-                Image(systemName: "arrow.right")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 15, height: 11)
-            }
-            .padding(.vertical, 17)
-            
-            Divider()
-            .frame(height: 0.5)
-            .opacity(isDividerExist ? 1 : 0)
+    // MARK: - Content
+    
+    @ViewBuilder
+    private var content: some View {
+        switch store.state.phase {
+        case .idle:
+            list(items: store.state.history, isHistory: true)
+        case .loaded(let results):
+            list(items: results, isHistory: false)
+        case .empty:
+            emptyView
         }
-        .padding(.horizontal, 35)
-        .foregroundColor(.label.secondary)
+    }
+    
+    private func list(items: [String], isHistory: Bool) -> some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 0) {
+                ForEach(items.indices, id: \.self) { index in
+                    cell(
+                        title: items[index],
+                        isDividerExist: items.count - 1 != index,
+                        action: {
+                            if isHistory {
+                                store.send(.selectHistory(index))
+                                queryInput = items[index]
+                            }
+                        }
+                    )
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+    
+    private var emptyView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.largeTitle)
+                .foregroundColor(.label.secondary)
+            Text("search.empty.title")
+                .font(.headline)
+                .foregroundColor(.label.primary)
+            Text("search.empty.subtitle")
+                .font(.caption)
+                .foregroundColor(.label.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 40)
+    }
+    
+    private func cell(
+        title: String,
+        isDividerExist: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack {
+                HStack {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundColor(.label.primary)
+                    
+                    Spacer()
+                    
+                    Image(systemName: "arrow.right")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 15, height: 11)
+                }
+                .padding(.vertical, 17)
+                
+                Divider()
+                    .frame(height: 0.5)
+                    .opacity(isDividerExist ? 1 : 0)
+            }
+            .padding(.horizontal, 35)
+            .foregroundColor(.label.secondary)
+        }
+        .buttonStyle(.plain)
     }
     
 }
@@ -91,9 +162,16 @@ private extension SearchResultsUi {
     }
     
     var headerImage: some View {
-        Image("search-result-background")
-        .resizable()
-        .ignoresSafeArea()
+        LinearGradient(
+            gradient: Gradient(colors: [
+                Color.background.secondary,
+                Color.background.primary
+            ]),
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .frame(height: 180)
+        .ignoresSafeArea(edges: .top)
     }
     
 }
@@ -113,10 +191,10 @@ private extension SearchResultsUi {
     
     var backButtonImage: some View {
         Image(systemName: "arrow.backward")
-        .resizable()
-        .scaledToFit()
-        .frame(width: 20, height: 14)
-        .foregroundColor(.label.primary)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 20, height: 14)
+            .foregroundColor(.label.primary)
     }
     
     var helpTooltip: some View {
@@ -134,18 +212,18 @@ private extension SearchResultsUi {
     
     var helpTooltipTitle: some View {
         Text("search.tooltip.swipe")
-        .font(.callout)
-        .foregroundColor(.label.primary)
-        .fontWeight(.bold)
+            .font(.callout)
+            .foregroundColor(.label.primary)
+            .fontWeight(.bold)
     }
     
     var helpTooltipImage: some View {
         Image(systemName: "chevron.left")
-        .resizable()
-        .scaledToFit()
-        .frame(width: 10, height: 8)
-        .foregroundColor(.label.primary)
-        .rotationEffect(.degrees(180))
+            .resizable()
+            .scaledToFit()
+            .frame(width: 10, height: 8)
+            .foregroundColor(.label.primary)
+            .rotationEffect(.degrees(180))
     }
     
 }
@@ -153,3 +231,4 @@ private extension SearchResultsUi {
 #Preview {
     SearchResultsUi()
 }
+

--- a/recepies/Sources/SearchResults/SearchState.swift
+++ b/recepies/Sources/SearchResults/SearchState.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct SearchState: Equatable {
+    
+    let history: [String]
+    let phase: Phase
+    
+    init(
+        history: [String] = SearchState.mockHistory,
+        phase: Phase = .idle
+    ) {
+        self.history = history
+        self.phase = phase
+    }
+    
+    enum Phase: Equatable {
+        case idle
+        case loaded([String])
+        case empty
+    }
+}
+
+// MARK: - Mock
+
+extension SearchState {
+    
+    static let mockHistory: [String] = [
+        "My search history",
+        "My favourite recipes",
+        "Easy Mexican Casserole",
+        "Pasta carbonara",
+        "Chocolate cake",
+        "Greek salad",
+        "Tom Yum soup"
+    ]
+}

--- a/recepies/Sources/SearchResults/SearchStore.swift
+++ b/recepies/Sources/SearchResults/SearchStore.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Observation
+
+@Observable
+final class SearchStore {
+    
+    private(set) var state: SearchState
+    
+    @ObservationIgnored
+    private var searchTask: Task<Void, Never>?
+    
+    init(state: SearchState = SearchState()) {
+        self.state = state
+    }
+    
+    func send(_ intent: SearchIntent) {
+        state = Self.reduce(state, intent)
+        handleEffect(for: intent)
+    }
+    
+    // MARK: - Pure reducer
+    
+    static func reduce(_ state: SearchState, _ intent: SearchIntent) -> SearchState {
+        switch intent {
+        case .submit(let query):
+            return handleSubmit(state: state, query: query)
+        case .resultsLoaded(let results):
+            return handleResultsLoaded(state: state, results: results)
+        case .clear:
+            return handleClear(state: state)
+        case .selectHistory(let index):
+            return handleSelectHistory(state: state, index: index)
+        }
+    }
+}
+
+// MARK: - Pure handlers
+
+private extension SearchStore {
+    
+    static func handleSubmit(state: SearchState, query: String) -> SearchState {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        return SearchState(
+            history: state.history,
+            phase: trimmed.isEmpty ? .idle : state.phase
+        )
+    }
+    
+    static func handleResultsLoaded(
+        state: SearchState,
+        results: [String]
+    ) -> SearchState {
+        SearchState(
+            history: state.history,
+            phase: results.isEmpty ? .empty : .loaded(results)
+        )
+    }
+    
+    static func handleClear(state: SearchState) -> SearchState {
+        SearchState(
+            history: state.history,
+            phase: .idle
+        )
+    }
+    
+    static func handleSelectHistory(state: SearchState, index: Int) -> SearchState {
+        guard state.history.indices.contains(index) else { return state }
+        
+        let picked = state.history[index]
+        return SearchState(
+            history: state.history,
+            phase: .loaded([picked])
+        )
+    }
+}
+
+// MARK: - Side effects
+
+private extension SearchStore {
+    
+    func handleEffect(for intent: SearchIntent) {
+        switch intent {
+        case .submit(let query):
+            performSearch(query: query)
+        case .resultsLoaded, .clear, .selectHistory:
+            break
+        }
+    }
+    
+    func performSearch(query: String) {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard trimmed.isEmpty == false else { return }
+        
+        searchTask?.cancel()
+        searchTask = Task {
+            let matches = state.history.filter {
+                $0.localizedCaseInsensitiveContains(trimmed)
+            }
+            guard Task.isCancelled == false else { return }
+            send(.resultsLoaded(matches))
+        }
+    }
+}

--- a/recepies/Tests/SearchStoreTests.swift
+++ b/recepies/Tests/SearchStoreTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+@testable import recepies
+
+final class SearchStoreTests: XCTestCase {
+    
+    // MARK: - submit
+    
+    func test_submit_nonEmpty_leavesPhaseUnchanged() {
+        let initial = SearchState(history: ["pasta"], phase: .idle)
+        let next = SearchStore.reduce(initial, .submit("pa"))
+        XCTAssertEqual(next.phase, .idle)
+    }
+    
+    func test_submit_emptyString_setsIdle() {
+        let initial = SearchState(
+            history: ["pasta"],
+            phase: .loaded(["pasta"])
+        )
+        let next = SearchStore.reduce(initial, .submit("   "))
+        XCTAssertEqual(next.phase, .idle)
+    }
+    
+    // MARK: - resultsLoaded
+    
+    func test_resultsLoaded_withItems_setsLoaded() {
+        let initial = SearchState(history: ["pasta", "pizza"], phase: .idle)
+        let next = SearchStore.reduce(initial, .resultsLoaded(["pasta"]))
+        XCTAssertEqual(next.phase, .loaded(["pasta"]))
+    }
+    
+    func test_resultsLoaded_empty_setsEmpty() {
+        let initial = SearchState(history: ["pasta"], phase: .idle)
+        let next = SearchStore.reduce(initial, .resultsLoaded([]))
+        XCTAssertEqual(next.phase, .empty)
+    }
+    
+    // MARK: - clear
+    
+    func test_clear_setsIdle() {
+        let initial = SearchState(
+            history: ["pasta", "pizza"],
+            phase: .loaded(["pasta"])
+        )
+        let next = SearchStore.reduce(initial, .clear)
+        XCTAssertEqual(next.phase, .idle)
+    }
+    
+    // MARK: - selectHistory
+    
+    func test_selectHistory_validIndex_setsLoadedWithSingleItem() {
+        let initial = SearchState(history: ["pasta", "pizza", "salad"])
+        let next = SearchStore.reduce(initial, .selectHistory(1))
+        XCTAssertEqual(next.phase, .loaded(["pizza"]))
+    }
+    
+    func test_selectHistory_outOfBounds_leavesStateUntouched() {
+        let initial = SearchState(history: ["pasta"])
+        let next = SearchStore.reduce(initial, .selectHistory(42))
+        XCTAssertEqual(next, initial)
+    }
+}


### PR DESCRIPTION
## Что сделано

Перевёл экран SearchResultsUi с хардкод-списка на MVI.

### Как устроено

Поток данных: User => Intent => Reducer => State => View

**SearchState** - struct с let-полями, phase как enum (idle / loaded / empty).
Текст из поля ввода живёт в @State у View, Store его не хранит.

**SearchIntent** - четыре кейса. `resultsLoaded` прилетает от side effect,
остальные три от юзера.

**SearchStore** - `@Observable`. Reducer статический, хэндлеры возвращают
новый экземпляр State через полный init. Side effects отделены в `handleEffect`.
`performSearch` обёрнут в Task с отменой предыдущего `searchTask?.cancel()`
и проверкой `Task.isCancelled` перед отправкой результата.

**SearchResultsUi** - контент рендерится через switch по `state.phase`.
TextField с `.onSubmit`, крестик очистки, тап по элементу истории.
Сырой ввод в `@State queryInput`, в Store уходит только submit.

### Попутные визуальные фиксы

- `Image("search-result-background")` => `LinearGradient`, ассета не было в каталоге
- `.customWeight(.heavy)` => `.headline`, убрал warning от Mirror-хака Inter
- `Color.white` => `Color.background.primary` - dark mode

### Тесты

7 тестов чистого reducer. Каждый - создал state, вызвал `SearchStore.reduce`,
проверил phase. Без моков, без async, без XCTestExpectation.

### Вне скоупа

- Реальный API вместо мок-фильтрации
- Фаза `.loading`
- `CancellationError` обработка и debouncing
- Навигация на экран детали рецепта